### PR TITLE
Install python 3.6 from testing target release

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -26,14 +26,15 @@ Shell over to your GameShell, and copy/paste the following:
 .. code-block:: bash
 
     echo "deb http://ftp.fr.debian.org/debian testing main" | sudo tee -a /etc/apt/sources.list
+    echo 'APT::Default-Release "stable";' | sudo tee -a /etc/apt/apt.conf.d/00local
 
 After you do that, run then following commands:
 
 .. code-block:: bash
 
     sudo apt-get update
-    sudo apt-get upgrade
-    sudo apt-get install -y python3.6
+
+    sudo apt-get -t testing install -y python3.6
 
 Install Arcade
 --------------
@@ -52,7 +53,7 @@ Now clone/grab the code from GitHub:
 .. code-block:: bash
 
     cd ~/games
-    git clone git@github.com:pvcraven/gameshell_template.git
+    git clone https://github.com/pvcraven/gameshell_template.git
 
 Install the Game
 ----------------


### PR DESCRIPTION
To avoid `apt upgrade` causing problems with current samba and music player daemon services.